### PR TITLE
feat: Increase card subtitle font size

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
                 <div class="bg-white rounded-xl shadow-lg overflow-hidden flex flex-col transform hover:-translate-y-2 transition-transform duration-300">
                     <div class="h-40 p-4 flex flex-col items-center justify-center text-center" style="background-color: ${recipe.bannerColor || '#6F4E37'};">
                         <h3 class="font-lora text-4xl font-bold text-black break-words">${recipe.beanName}</h3>
-                        <p class="font-lora text-lg text-black mt-1 country-origin">${recipe.country || ''}</p>
+                        <p class="font-lora text-2xl text-black mt-1 country-origin">${recipe.country || ''}</p>
                     </div>
                     <div class="p-6 flex-grow flex flex-col justify-between">
                         <div class="grid grid-cols-3 text-center divide-x divide-stone-200">


### PR DESCRIPTION
The font size of the card subtitles (country of origin) has been increased from text-lg to text-2xl to improve readability.