### PR TITLE
Fix: Populate edit modal with correct data from state

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,7 @@
         let db, auth, userId;
         let unsubscribeFromRecipes = null;
         let recipeIdToDelete = null;
+        let allRecipes = [];
 
         /**
          * Renders the recipe cards on the page.
@@ -318,26 +319,21 @@
 
         function handleEditClick(e) {
             const id = e.target.dataset.id;
-            const recipeCard = e.target.closest('.bg-white');
-            const recipe = {
-                id: id,
-                beanName: recipeCard.querySelector('h3').textContent,
-                country: recipeCard.querySelector('.country-origin').textContent,
-                bannerColor: recipeCard.querySelector('[style^="background-color"]').style.backgroundColor,
-                coffeeAmount: recipeCard.querySelector('.grid > div:nth-child(1) .font-semibold').textContent.replace('g', ''),
-                grindSize: recipeCard.querySelector('.grid > div:nth-child(2) .font-semibold').textContent,
-                yieldAmount: recipeCard.querySelector('.grid > div:nth-child(3) .font-semibold').textContent.replace('g', ''),
-            };
-            
-            document.getElementById('recipeId').value = recipe.id;
-            document.getElementById('beanName').value = recipe.beanName;
-            document.getElementById('country').value = recipe.country;
-            const rgb = recipe.bannerColor.match(/\d+/g);
-            const hex = rgb ? `#${parseInt(rgb[0]).toString(16).padStart(2, '0')}${parseInt(rgb[1]).toString(16).padStart(2, '0')}${parseInt(rgb[2]).toString(16).padStart(2, '0')}` : '#6F4E37';
-            document.getElementById('bannerColor').value = hex;
-            document.getElementById('coffeeAmount').value = recipe.coffeeAmount;
-            document.getElementById('grindSize').value = recipe.grindSize;
-            document.getElementById('yieldAmount').value = recipe.yieldAmount;
+            const recipeToEdit = allRecipes.find(recipe => recipe.id === id);
+
+            if (!recipeToEdit) {
+                console.error("Recipe not found for editing!");
+                alert("Could not find recipe data to edit. Please try again.");
+                return;
+            }
+
+            document.getElementById('recipeId').value = recipeToEdit.id;
+            document.getElementById('beanName').value = recipeToEdit.beanName;
+            document.getElementById('country').value = recipeToEdit.country || '';
+            document.getElementById('bannerColor').value = recipeToEdit.bannerColor || '#6F4E37';
+            document.getElementById('coffeeAmount').value = recipeToEdit.coffeeAmount;
+            document.getElementById('grindSize').value = recipeToEdit.grindSize;
+            document.getElementById('yieldAmount').value = recipeToEdit.yieldAmount;
             
             modalTitle.textContent = 'Edit Recipe';
             toggleFormModal(true);
@@ -370,7 +366,8 @@
                 querySnapshot.forEach((doc) => {
                     recipes.push({ id: doc.id, ...doc.data() });
                 });
-                renderRecipes(recipes);
+                allRecipes = recipes;
+                renderRecipes(allRecipes);
             }, (error) => {
                 console.error("Error fetching recipes:", error);
                 renderRecipes([]);


### PR DESCRIPTION
The previous implementation scraped data directly from the DOM when you clicked the 'Edit' button. This was brittle and could lead to incorrect data being shown in the edit modal, especially with complex data types like colors.

I refactored the logic to:
1. Store the fetched recipes in a module-scoped `allRecipes` array, which serves as the single source of truth.
2. Modify the `handleEditClick` function to find the recipe in the `allRecipes` array by its ID and use that object's data to populate the modal.

This ensures the edit modal is always populated with the pristine data from the database.