### PR TITLE
feat: Add notes section to recipe cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,11 @@
                             <input type="number" id="yieldAmount" name="yieldAmount" step="1" required class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-[#6F4E37] focus:border-[#6F4E37] transition-colors" placeholder="250">
                         </div>
                     </div>
+
+                    <div>
+                        <label for="notes" class="block text-sm font-medium text-stone-700 mb-1">Notes</label>
+                        <textarea id="notes" name="notes" rows="3" class="w-full px-4 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-[#6F4E37] focus:border-[#6F4E37] transition-colors" placeholder="e.g., Bloom for 45s, pour in circles..."></textarea>
+                    </div>
                 </div>
 
                 <!-- Form Actions -->
@@ -250,6 +255,14 @@
                                 <p class="font-semibold text-xl">${recipe.yieldAmount}g</p>
                             </div>
                         </div>
+
+                        ${recipe.notes ? `
+                        <div class="mt-4 pt-4 border-t border-stone-200">
+                            <p class="text-sm text-stone-500 mb-1">Notes</p>
+                            <p class="text-stone-700 whitespace-pre-wrap">${recipe.notes}</p>
+                        </div>
+                        ` : ''}
+
                         <div class="mt-6 pt-4 border-t border-stone-200 flex justify-end gap-2">
                             <button class="edit-btn text-sm text-stone-600 hover:text-blue-600 font-semibold py-1 px-3 rounded" data-id="${recipe.id}">Edit</button>
                             <button class="delete-btn text-sm text-stone-600 hover:text-red-600 font-semibold py-1 px-3 rounded" data-id="${recipe.id}">Delete</button>
@@ -302,6 +315,7 @@
                 coffeeAmount: parseFloat(document.getElementById('coffeeAmount').value),
                 grindSize: document.getElementById('grindSize').value,
                 yieldAmount: parseFloat(document.getElementById('yieldAmount').value),
+                notes: document.getElementById('notes').value,
             };
 
             try {
@@ -334,6 +348,7 @@
             document.getElementById('coffeeAmount').value = recipeToEdit.coffeeAmount;
             document.getElementById('grindSize').value = recipeToEdit.grindSize;
             document.getElementById('yieldAmount').value = recipeToEdit.yieldAmount;
+            document.getElementById('notes').value = recipeToEdit.notes || '';
             
             modalTitle.textContent = 'Edit Recipe';
             toggleFormModal(true);


### PR DESCRIPTION
This commit introduces a new 'notes' section to the coffee recipes.

- Adds a textarea to the add/edit recipe modal to allow you to enter notes.
- Updates the recipe card template to display the notes under the coffee/grind/yield details. The notes section is only shown if notes exist.
- Modifies the form submission handler to save the notes to Firestore.
- Updates the edit functionality to populate the notes textarea when editing a recipe.