### PR TITLE
feat: Center recipe cards using flexbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
         <!-- Logged In Content -->
         <div id="loggedInContent" class="hidden">
             <!-- Recipe Cards Grid -->
-            <div id="recipesContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 md:gap-8">
+            <div id="recipesContainer" class="flex flex-wrap justify-center gap-6 md:gap-8">
                 <!-- Recipe cards will be injected here by JavaScript -->
             </div>
              <!-- Placeholder for when there are no recipes -->
@@ -235,7 +235,7 @@
             
             noRecipesMessage.classList.add('hidden');
             recipesContainer.innerHTML = recipes.map(recipe => `
-                <div class="bg-white rounded-xl shadow-lg overflow-hidden flex flex-col transform hover:-translate-y-2 transition-transform duration-300">
+                <div class="bg-white rounded-xl shadow-lg overflow-hidden flex flex-col transform hover:-translate-y-2 transition-transform duration-300 w-72">
                     <div class="h-40 p-4 flex flex-col items-center justify-center text-center" style="background-color: ${recipe.bannerColor || '#6F4E37'};">
                         <h3 class="font-lora text-4xl font-bold text-black break-words">${recipe.beanName}</h3>
                         <p class="font-lora text-2xl text-black mt-1 country-origin">${recipe.country || ''}</p>


### PR DESCRIPTION
This commit replaces the grid-based layout for recipe cards with a flexbox-based layout. This allows the cards to be centered horizontally on the page.

The `recipesContainer` is changed to use `flex`, `flex-wrap`, and `justify-center`.

A fixed width of `w-72` is added to each card to ensure a consistent layout and to enforce a maximum of 3 cards per line on most screen sizes.